### PR TITLE
Fixes to score screen and individual score semester

### DIFF
--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -6,7 +6,12 @@ import MyWidgetScoreSemesterSummary from './my-widgets-score-semester-summary'
 import LoadingIcon from './loading-icon'
 
 const showScore = (instId, playId) => window.open(`/scores/single/${playId}/${instId}`)
-const _compareWidgets = (a, b) => { return (b.created_at - a.created_at) }
+const _compareScores = (a, b) => { return (parseInt(b.created_at) - parseInt(a.created_at)) }
+
+const timestampToDateDisplay = timestamp => {
+	const d = new Date(parseInt(timestamp, 10) * 1000)
+	return d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
+}
 
 const initState = () => ({
 	isLoading: true,
@@ -54,9 +59,8 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId }) => {
 					else {
 						for (let scoreIndex = 0; scoreIndex < scoreObject.scores.length; scoreIndex++)
 							newLogs[scoreObject.userId].scores.push(scoreObject.scores[scoreIndex])
-
-						newLogs[scoreObject.userId].scores.sort(_compareWidgets).reverse()
 					}
+					newLogs[scoreObject.userId].scores.sort(_compareScores)
 				}
 
 				setLogsList(newLogs)
@@ -114,7 +118,7 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId }) => {
 					title='View Detailed Scores for this Play'
 					onClick={() => { showScore(instId, score.playId) }}
 				>
-					<td>{score.date}</td>
+					<td>{timestampToDateDisplay(score.created_at)}</td>
 					<td>{score.score}</td>
 					<td>{score.elapsed}</td>
 				</tr>

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -233,12 +233,17 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		if (!!attempts) {
 			if (attempts instanceof Array && attempts.length > 0) {
 				let matchedAttempt = false
+				// Reverse attempts so that the most recent attempt has the highest index
+				attempts.reverse()
+
+				// attemptDates is used to populate the overview data in displayWidgetInstance, it's just assembled here.
+				let dates = [ ...attemptDates ]
+
 				// sort added here so it displays the correct date with the attempt and score
 				attempts.forEach((a, i) => {
 					const d = new Date(a.created_at * 1000)
 
 					// attemptDates is used to populate the overview data in displayWidgetInstance, it's just assembled here.
-					let dates = { ...attemptDates }
 					let date = { ...dates[i] }
 					date = d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
 					dates[i] = date
@@ -282,15 +287,15 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 	}, [currentAttempt])
 
 	useEffect(() => {
-		if (!!playId) loadPlayScores()
+		if (!!playId) 
+		{
+			loadPlayScores()
+		}
 	}, [playId])
 
 	useEffect(() => {
 
 		if (playScores && playScores.length > 0) {
-
-			// if (!customScoreScreen.show) {
-			// }
 
 			const deets = playScores[0]
 			setDetails([...deets.details])
@@ -338,11 +343,6 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 	const listenToHashChange = () => {
 		const hash = getAttemptNumberFromHash()
 		if (currentAttempt != hash) setCurrentAttempt(hash)
-
-		if (customScoreScreen.show) {
-			// update the customScoreScreen
-			_sendWidgetUpdate()
-		}
 	}
 
 	const _populateScores = (scores) => {
@@ -553,9 +553,13 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		_sendToWidget('initWidget', [customScoreScreen.qset, customScoreScreen.scoreTable, instance, isPreview, window.MEDIA_URL])
 	}
 
-	const _sendWidgetUpdate = () => {
-		_sendToWidget('updateWidget', [qset, scoreTable])
-	}
+	useEffect(() => {
+		if (scoreWidgetRef.current != null)
+		{
+			// the "update" function is not implemented by every custom score screen, have to send "start"
+			_sendToWidget('initWidget', [customScoreScreen.qset, customScoreScreen.scoreTable, instance, isPreview, window.MEDIA_URL])
+		}
+	}, [customScoreScreen.scoreTable])
 
 	const _setHeight = (h) => {
 		const min_h = instance.widget.height
@@ -593,7 +597,8 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 					</a>
 				</li>
 			)
-		})
+		}).reverse()
+		// Reverses attempt list so that the most recent appears at top
 
 		previousAttempts = (
 			<nav

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -464,11 +464,6 @@ export const apiGetPlayLogs = (instId, term, year, page_number) => {
 		.then(results => {
 			if (results.pagination.length == 0) return []
 
-			const timestampToDateDisplay = timestamp => {
-				const d = new Date(parseInt(timestamp, 10) * 1000)
-				return d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
-			}
-
 			const scoresByUser = new Map()
 			results.pagination.forEach(log => {
 				let scoresForUser
@@ -496,7 +491,7 @@ export const apiGetPlayLogs = (instId, term, year, page_number) => {
 					elapsed: parseInt(log.elapsed, 10) + 's',
 					playId: log.id,
 					score: log.done === '1' ? Math.round(parseFloat(log.perc)) + '%' : '---',
-					date: timestampToDateDisplay(log.time)
+					created_at: log.time
 				})
 
 			})


### PR DESCRIPTION
Addresses issues mentioned in [#1448](https://github.com/ucfopen/Materia/pull/1448)

- Most recent score now has the greatest index
- Attempt dates are displayed for all attempts
- Score screen now updates with selected attempt (tested for both custom and non-custom score screens)
- Individual semester scores are ordered with the most recent at top