### PR TITLE
Perm manager's get_all_objects_for_user no longer returns objects available via role

### DIFF
--- a/fuel/app/classes/materia/perm/manager.php
+++ b/fuel/app/classes/materia/perm/manager.php
@@ -552,7 +552,10 @@ class Perm_Manager
 	}
 
 	/**
-	 * Gets an array of object id's that a user has permissions for matching any of the requested permissions.
+	 * Gets an array of object ids of a given type that a user has EXPLICIT permissions to that matches the perms provided.
+	 * (!!!) NOTE: Previously, this method would also return IMPLICITLY available objects based on the user's role (if elevated).
+	 * This is no longer the case. If IMPLICITLY available objects are required, use get_all_objects_for_elevated_user_role
+	 * 
 	 * If an object has any of the requested permissions, it will be returned.
 	 * Perm_Manager->get_all_objects_for_users($user->user_id, \Materia\Perm::INSTANCE, [\Materia\Perm::SHARE]);
 	 *
@@ -570,41 +573,62 @@ class Perm_Manager
 			// WHERE id IN (5, 6) whould match ids that ***START*** with 5 or 6
 			foreach ($perms as &$value) $value = (string) $value;
 
-			// ====================== GET THE USERS ROLE PERMISSIONS ============================
-			// build a subquery that gets any roles the user has
-			$subquery_role_ids = \DB::select('role_id')
-				->from('perm_role_to_user')
-				->where('user_id', $user_id);
-
-			// get any perms that users roles have
-			$roles_perms = \DB::select('perm')
-				->from('perm_role_to_perm')
-				->where('role_id', 'IN', $subquery_role_ids)
+			// ==================== GET USER's EXPLICIT PERMISSSION ==============================
+			// get objects that the user has direct access to
+			$objects = \DB::select('object_id')
+				->from('perm_object_to_user')
+				->where('object_type', $object_type)
+				->where('user_id', $user_id)
 				->where('perm', 'IN', $perms)
-				->execute();
-
-			// Only super_user has role perm 30 -- get all assets/widgets
-			if ($roles_perms->count() != 0)
-			{
-				$objects = \DB::select('id')
-					->from($object_type == Perm::ASSET ? 'asset' : 'widget_instance')
-					->execute()
-					->as_array('id', 'id');
-			}
-			else
-			{
-				// ==================== GET USER's EXPLICIT PERMISSSION ==============================
-				// get objects that the user has direct access to
-				$objects = \DB::select('object_id')
-					->from('perm_object_to_user')
-					->where('object_type', $object_type)
-					->where('user_id', $user_id)
-					->where('perm', 'IN', $perms)
-					->execute()
-					->as_array('object_id', 'object_id');
-			}
+				->execute()
+				->as_array('object_id', 'object_id');
 			return $objects;
 		}
+	}
+
+	/**
+	 * Gets an array of object ids that a user has permissions to access EXCLUSIVELY based on an elevated role
+	 * This requires the user has a role with elevated perms, and that the group rights associated with those perms are present in the perm_role_to_perm table
+	 * Currently, the role must be Perm::ADMINISTRATOR or Perm::SUPERUSER
+	 * 
+	 * Perm_Manager->get_all_objects_for_users($user->user_id, \Materia\Perm::INSTANCE);
+	 *
+	 * @param int User ID the get permissions for
+	 * @param int Object type as defined in Perm constants
+	 */
+	static public function get_all_objects_for_elevated_user_role($user_id, $object_type)
+	{
+		$objects = [];
+		$user_is_admin_or_su = false;
+
+		// ====================== GET THE USERS ROLE PERMISSIONS ============================
+		// build a subquery that gets any roles the user has
+		$subquery_role_ids = \DB::select('role_id')
+			->from('perm_role_to_user')
+			->where('user_id', $user_id);
+
+		// get any perms that users roles have
+		$roles_perms = \DB::select('perm')
+			->from('perm_role_to_perm')
+			->where('role_id', 'IN', $subquery_role_ids)
+			->execute();
+
+		
+		// verify that perms returned from perm_role_to_perm table are elevated
+		// this means either Perm::ADMINISTRATOR (85) or Perm::SUPERUSER (90)
+		foreach ($roles_perms as $role)
+		{
+			if (is_array($role) && $role['perm'] >= Perm::ADMINISTRATOR) $user_is_admin_or_su = true;
+		}
+
+		if ($user_is_admin_or_su == true)
+		{
+			$objects = \DB::select('id')
+				->from($object_type == Perm::ASSET ? 'asset' : 'widget_instance')
+				->execute()
+				->as_array('id', 'id');
+		}
+		return $objects;
 	}
 
 	/**


### PR DESCRIPTION
`get_all_objects_for_user` would previously return both objects with explicit access, and objects available to users based on their role. This meant that users with elevated access (`support_user` and `super_user`) would see ALL widget instances in My Widgets and ALL assets in the media importer. These are massive API calls, and instance management from My Widgets is no longer required thanks to the instance management interface.