### PR TITLE
Adds user role manager to user admin interface

### DIFF
--- a/fuel/app/classes/controller/api/user.php
+++ b/fuel/app/classes/controller/api/user.php
@@ -39,4 +39,58 @@ class Controller_Api_User extends Controller_Rest
 
 		return $this->response($reply);
 	}
+
+	public function post_roles()
+	{
+		if (\Service_User::verify_session() !== true) return $this->response('Not logged in', 401);
+		// this endpoint is only available to superusers!
+		if ( ! \Materia\Perm_Manager::is_super_user()) return $this->response('Not authorized', 403);
+
+		$success = false;
+		$user_id = Input::json('id', null);
+		$roles = [
+			'basic_author' => Input::json('author', false),
+			'support_user' => Input::json('support_user', false)
+		];
+
+		if ( ! $user_id) return $this->response('User ID not provided', 401);
+
+		$current_roles = \Materia\Perm_Manager::get_user_roles($user_id);
+		$current_roles_condensed = array_map( fn($r) => $r->name, $current_roles);
+
+		$roles_to_add = [];
+		$roles_to_revoke = [];
+
+		foreach ($roles as $name => $val)
+		{
+			if ( ! in_array($name, $current_roles_condensed) && $val == true) array_push($roles_to_add, $name);
+			else if (in_array($name, $current_roles_condensed) && $val == false) array_push($roles_to_revoke, $name);
+		}
+
+		$message = '';
+
+		if (count($roles_to_add) > 0)
+		{
+			$success = \Materia\Perm_Manager::add_users_to_roles([$user_id], $roles_to_add);
+			if ($success != true) return $this->response(['success' => false, 'status' => 'Failed to add roles']);
+			$message .= count($roles_to_add).' role(s) added.';
+		}
+
+		if (count($roles_to_revoke) > 0)
+		{
+			$success = \Materia\Perm_Manager::remove_users_from_roles([$user_id], $roles_to_revoke);
+			if ($success != true) return $this->response(['success' => false, 'status' => 'Failed to revoke roles']);
+			$message .= count($roles_to_revoke).' role(s) revoked.';
+		}
+
+		if (strlen($message) == 0)
+		{
+			$message .= 'No roles were changed.';
+		}
+
+		return $this->response([
+			'success' => true,
+			'status'  => $message
+		]);
+	}
 }

--- a/fuel/app/classes/materia/perm/manager.php
+++ b/fuel/app/classes/materia/perm/manager.php
@@ -280,12 +280,11 @@ class Perm_Manager
 			->as_object();
 
 		$current_id = \Model_User::find_current_id();
+		$roles = [];
 
 		// return logged in user's roles if id is 0 or less, non su users can only use this method
 		if ($user_id <= 0 || $user_id == $current_id)
 		{
-			$roles = [];
-
 			$results = $q->where('m.user_id', $current_id)
 				->execute();
 

--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -160,6 +160,7 @@ class Model_User extends Orm\Model
 		$array['avatar'] = $avatar;
 		$array['is_student'] = \Materia\Perm_Manager::is_student($this->id);
 		$array['is_support_user'] = \Materia\Perm_Manager::does_user_have_role([\Materia\Perm_Role::SUPPORT], $this->id);
+		if (\Materia\Perm_Manager::does_user_have_role([\Materia\Perm_Role::SU], $this->id)) $array['is_super_user'] = true;
 		return $array;
 	}
 

--- a/src/components/hooks/useUpdateUserRoles.jsx
+++ b/src/components/hooks/useUpdateUserRoles.jsx
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from 'react-query'
+import { apiUpdateUserRoles } from '../../util/api'
+
+export default function useUpdateUserRoles() {
+	
+	const queryClient = useQueryClient()
+
+	return useMutation(
+		apiUpdateUserRoles,
+		{
+			onMutate: async roles => {
+				await queryClient.cancelQueries('search-users')
+				const val = {...queryClient.getQueryData('search-users')}
+				const prior = queryClient.getQueryData('search-users')
+
+				queryClient.setQueryData('search-users', () => val)
+
+				return { prior }
+			},
+			onSuccess: (data, variables, context) => {
+				queryClient.invalidateQueries('search-users')
+				variables.successFunc(data)
+			},
+			onError: (err, newRoles, context) => {
+				queryClient.setQueryData('search-users', context.previousValue)
+				return err
+			}
+		}
+	)
+}

--- a/src/components/user-admin-page.scss
+++ b/src/components/user-admin-page.scss
@@ -5,11 +5,11 @@
 	position: relative;
 	top: 40px;
 	margin: 10px auto;
-	padding: 0 10px 10px;
+	padding: 0px;
 	display: block;
 	border: 1px solid #ccc;
 	box-shadow: 0 0 10px #aaa;
-	width: 700px;
+	width: 720px;
 
 	.page {
 
@@ -18,7 +18,6 @@
 			position: absolute;
 			top: -40px;
 			left: -10px;
-			// margin-left: 10px;
 			padding: 5px 10px;
 			background: #eee;
 			border-radius: 3px;
@@ -42,10 +41,8 @@
 
 		.top {
 			position: relative;
-			top: 0;
-			left: -10px;
 			padding: 10px;
-			width: 100%;
+			width: calc(100% - 20px);
 
 			color: #ffffff;
 			background: $gray;
@@ -74,6 +71,28 @@
 				border-radius: 5px;
 				border: solid 1px $gray;
 			}
+
+			.instance_search {
+				width: 200px;
+			}
+		}
+
+		.search_match {
+			box-sizing: border-box;
+			display: inline-block;
+			width: 48%;
+			margin: 5px;
+			padding: 10px;
+			border: 1px solid #d3d3d3;
+		
+			> div {
+				display: inline-block;
+			}
+		}
+		
+		.searching {
+			vertical-align: bottom;
+			margin-top: 10px;
 		}
 
 		.show_deleted {
@@ -151,12 +170,210 @@
 			}
 		}
 
-		.inst-info {
-			margin: 10px 0;
+		.admin-subsection {
+			padding: 15px;
+		
+			.top {
+				width: calc(100% + 10px);
+				left: -15px;
+			}
 
-			div {
-				display: inline-block;
-				margin: 5px 0 0;
+			&.overview {
+				width: calc(100% - 20px);
+				padding: 10px;
+	
+				div {
+					display: block;
+					margin: 0;
+				}
+	
+				span {
+					display: block;
+					margin: 5px 0;
+				}
+	
+				label {
+					display: inline-block;
+					vertical-align: top;
+					width: 160px;
+				}
+	
+				.radio {
+					display: inline-block;
+					// width: 200px;
+	
+					input {
+						margin: 0px 5px;
+					}
+	
+					label {
+						width: auto;
+					}
+				}
+	
+				.url {
+					display: inline-block;
+					vertical-align: middle;
+					// width: 500px;
+					font-size: 70%;
+					margin: 0px 0px;
+				}
+	
+				.right-justify {
+					display: flex;
+					justify-content: flex-end;
+					margin-top: 20px;
+	
+					.apply-changes {
+						display: flex;
+						flex-direction: column;
+						justify-content: flex-end;
+						width: 220px;
+						margin-right: 20px;
+	
+						.apply {
+							padding: 6px 10px 6px 10px;
+						}
+	
+						.error-text {
+							color: red;
+							font-size: 0.8em;
+							text-align: center;
+						}
+	
+						.success-text {
+							color: green;
+							font-size: 0.8em;
+							text-align: center;
+						}
+					}
+				}
+			}
+
+			&.role-manager {
+				ul {
+					padding: 10px;
+					list-style-type: none;
+
+					li {
+						font-weight: bold;
+						margin-bottom: 5px;
+
+						label {
+							margin-left: 10px;
+						}
+					}
+
+				}
+
+				dl.update-status {
+					dt {
+						display: inline-block;
+						font-weight: bold;
+					}
+
+					dd {
+						display: inline-block;
+						margin-left: 1em;
+					}
+				}
+			}
+
+			&.instances {
+
+				ul {
+					width: 100%;
+					padding: 0;
+					flex-direction: row;
+					list-style-type: none;
+				
+					li.instance {
+						margin: 0 0 10px 0;
+				
+						border-radius: 3px;
+						
+						.img-holder {
+							display: inline-block;
+							vertical-align: middle;
+				
+							img {
+								width: 50px;
+								height: 50px;
+								-moz-border-radius: 3px;
+								border-radius: 3px;
+								display: inline-block;
+								margin-right: 10px;
+							}
+						}
+				
+						div.widget-title {
+							display: flex;
+							justify-content: flex-start;
+							align-items: center;
+							gap: 10px;
+							padding: 10px 15px;
+				
+							background: $very-light-gray;
+							border: none;
+							border-radius: 3px;
+							transition: background-color 0.5s;
+				
+							span.img-holder {
+								flex-basis: 0;
+							}
+				
+							span.incomplete-status-holder {
+								color: #555;
+							}
+				
+							span.title-holder {
+								flex-grow: 1;
+				
+								.title {
+									margin: 0;
+									padding: 0;
+									vertical-align: middle;
+									font-weight: bold;
+									font-size: 20px;
+								}
+							}
+				
+							span.date-holder {
+								font-size: 12px;
+								font-weight: bold;
+							}
+						}
+				
+						.info-holder {
+							display: none;
+						}
+				
+						&.expanded {
+				
+							div.widget-title {
+								background: $light-gray;
+								border-bottom-left-radius: 0px;
+								border-bottom-right-radius: 0px;
+							}
+				
+							.manage-btn-container {
+								display: flex;
+								justify-content: end;
+								margin-top: 20px;
+							}
+				
+							.info-holder {
+								display: block;
+								padding: 15px;
+								background: $very-light-gray;
+								border-bottom-left-radius: 3px;
+								border-bottom-right-radius: 3px;
+				
+								line-height: 1.5em;
+							}
+						}
+					} 
+				}
 			}
 		}
 
@@ -194,77 +411,6 @@
 			}
 		}
 
-		.overview {
-			width: 100%;
-			padding: 10px;
-
-			div {
-				display: block;
-				margin: 0;
-			}
-
-			span {
-				display: block;
-				// margin: 5px 0px;
-			}
-
-			label {
-				display: inline-block;
-				vertical-align: top;
-				width: 160px;
-			}
-
-			.radio {
-				display: inline-block;
-				// width: 200px;
-
-				input {
-					margin: 0px 5px;
-				}
-
-				label {
-					width: auto;
-				}
-			}
-
-			.url {
-				display: inline-block;
-				vertical-align: middle;
-				// width: 500px;
-				font-size: 70%;
-				margin: 0px 0px;
-			}
-
-			.right-justify {
-				display: flex;
-				justify-content: flex-end;
-				margin-top: 20px;
-
-				.apply-changes {
-					display: flex;
-					flex-direction: column;
-					justify-content: flex-end;
-					width: 220px;
-					margin-right: 20px;
-
-					.apply {
-						padding: 6px 10px 6px 10px;
-					}
-
-					.error-text {
-						color: red;
-						font-size: 0.8em;
-						text-align: center;
-					}
-
-					.success-text {
-						color: green;
-						font-size: 0.8em;
-						text-align: center;
-					}
-				}
-			}
-		}
 	}
 
 	.page > ul {
@@ -282,150 +428,6 @@
 	}
 }
 
-.back {
-	// position: absolute;
-	top: 3px;
-	right: 5px;
-	cursor: pointer;
-	font-size: 120%;
-
-	.arrow {
-		display: inline-block;
-		padding-top: 19px;
-		margin-bottom: -4px;
-		width: 17px;
-		height: 0;
-		margin-right: 5px;
-		margin-left: -2px;
-
-		background: url(https://localhost/img/arrow.png) bottom no-repeat;
-	}
-}
-
-.instance_search {
-	width: 200px;
-}
-
-.search_match {
-	box-sizing: border-box;
-	display: inline-block;
-	width: 48%;
-	margin: 5px;
-	padding: 10px;
-	border: 1px solid #d3d3d3;
-
-	> div {
-		display: inline-block;
-	}
-}
-
-.searching {
-	vertical-align: bottom;
-	margin-top: 10px;
-}
-
 .clickable {
 	cursor: pointer;
 }
-
-.instances ul {
-	width: 100%;
-	padding: 0;
-	flex-direction: row;
-	list-style-type: none;
-
-	li.instance {
-		margin: 0 0 10px 0;
-
-		border-radius: 3px;
-		
-		.img-holder {
-			display: inline-block;
-			vertical-align: middle;
-
-			img {
-				width: 50px;
-				height: 50px;
-				-moz-border-radius: 3px;
-				border-radius: 3px;
-				display: inline-block;
-				margin-right: 10px;
-			}
-		}
-
-		div.widget-title {
-			display: flex;
-			justify-content: flex-start;
-			align-items: center;
-			gap: 10px;
-			padding: 10px 15px;
-
-			background: $very-light-gray;
-			border: none;
-			border-radius: 3px;
-			transition: background-color 0.5s;
-
-			span.img-holder {
-				flex-basis: 0;
-			}
-
-			span.incomplete-status-holder {
-				color: #555;
-			}
-
-			span.title-holder {
-				flex-grow: 1;
-
-				.title {
-					margin: 0;
-					padding: 0;
-					vertical-align: middle;
-					font-weight: bold;
-					font-size: 20px;
-				}
-			}
-
-			span.date-holder {
-				font-size: 12px;
-				font-weight: bold;
-			}
-		}
-
-		.info-holder {
-			display: none;
-		}
-
-		&.expanded {
-
-			div.widget-title {
-				background: $light-gray;
-				border-bottom-left-radius: 0px;
-				border-bottom-right-radius: 0px;
-			}
-
-			.manage-btn-container {
-				display: flex;
-				justify-content: end;
-				margin-top: 20px;
-			}
-
-			.info-holder {
-				display: block;
-				padding: 15px;
-				background: $very-light-gray;
-				border-bottom-left-radius: 3px;
-				border-bottom-right-radius: 3px;
-
-				line-height: 1.5em;
-			}
-		}
-	} 
-
-
-	
-
-	// span {
-	// 	display: inline-block;
-	// }
-}
-

--- a/src/components/user-admin-role-manager.jsx
+++ b/src/components/user-admin-role-manager.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import useUpdateUserRoles from './hooks/useUpdateUserRoles'
+
+const UserAdminRoleManager = ({currentUser, selectedUser}) => {
+
+	const [roles, setRoles] = useState({
+		student: selectedUser.is_student,
+		author: !selectedUser.is_student,
+		support_user: selectedUser.is_support_user
+	})
+	const [updateStatus, setUpdateStatus] = useState({
+		status: null,
+		message: ''
+	})
+	const userRolesMutation = useUpdateUserRoles()
+
+	const toggleRole = (e) => {
+		// note: student and author are mutually exclusive. A user cannot be both!
+		switch (e.target.name) {
+			case 'student':
+				setRoles({...roles, student: !roles.student, author: roles.student})
+				break
+			case 'author':
+				setRoles({...roles, author: !roles.author, student: roles.author})
+				break
+			case 'support':
+				setRoles({...roles, support_user: !roles.support_user})
+				break
+		}
+	}
+
+	const submitUpdateRoles = () => {
+		userRolesMutation.mutate({
+			id: selectedUser.id,
+			author: roles.author,
+			support_user: roles.support_user,
+			successFunc: (response) => {
+				setUpdateStatus({
+					status: response.success ? 'Successful.' : 'Error.',
+					message: response.status
+				})
+			}
+		})
+	}
+
+	let statusRender = null
+	if (updateStatus.status != null) {
+		statusRender = <dl className='update-status'>
+			<dt>{updateStatus.status}</dt>
+			<dd>{updateStatus.message}</dd>
+		</dl>
+	}
+
+	return (
+		<div className='admin-subsection role-manager'>
+			<div className='top'>
+				<h2>User Role Manager</h2>
+			</div>
+			<p>Current user roles:</p>
+			<ul className='roles'>
+				<li key='student'>
+					<input type='checkbox' id='student' name='student' checked={roles.student == true} onChange={toggleRole}></input>
+					<label>Student</label>
+				</li>
+				<li key='author'>
+					<input type='checkbox' id='author' name='author' checked={roles.author == true} onChange={toggleRole}></input>
+					<label>Author</label>
+				</li>
+				<li key='support'>
+					<input type='checkbox' id='support' name='support' checked={roles.support_user == true} onChange={toggleRole}></input>
+					<label>Support</label>
+				</li>
+			</ul>
+			<button className='action_button' onClick={submitUpdateRoles}>Submit</button>
+			{ statusRender }
+		</div>
+	)
+}
+
+export default UserAdminRoleManager

--- a/src/components/user-admin-selected.jsx
+++ b/src/components/user-admin-selected.jsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query'
 import { apiGetInstancesForUser } from '../util/api'
 import UserAdminInstanceAvailable from './user-admin-instance-available'
 import UserAdminInstancePlayed from './user-admin-instance-played'
+import UserAdminRoleManager from './user-admin-role-manager'
 
 const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 
@@ -45,25 +46,30 @@ const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 		}
 	}
 
+	let suRender = null
+	if (currentUser?.is_super_user) {
+		suRender = <UserAdminRoleManager currentUser={currentUser} selectedUser={selectedUser} />
+	}
+
 	return (
 		<section className='page inst-info'>
-			<div id="breadcrumb-container">
-				<div className="breadcrumb">
-					<a href="/admin/user">User Search</a>
+			<div id='breadcrumb-container'>
+				<div className='breadcrumb'>
+					<a href='/admin/user'>User Search</a>
 				</div>
-				<svg xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					viewBox="0 0 24 24">
-					<path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/>
-					<path fill="none" d="M0 0h24v24H0V0z"/>
+				<svg xmlns='http://www.w3.org/2000/svg'
+					width='24'
+					height='24'
+					viewBox='0 0 24 24'>
+					<path d='M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z'/>
+					<path fill='none' d='M0 0h24v24H0V0z'/>
 				</svg>
-				<div className="breadcrumb">{`${updatedUser.first} ${updatedUser.last}`}</div>
+				<div className='breadcrumb'>{`${updatedUser.first} ${updatedUser.last}`}</div>
 			</div>
 			<div className='top'>
 				<h1>{ `${updatedUser.first} ${updatedUser.last}` }</h1>
 			</div>
-			<div className='overview'>
+			<div className='overview admin-subsection'>
 				<span>
 					<label>ID: </label>{ updatedUser.id }
 				</span>
@@ -90,17 +96,18 @@ const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 					<label>User icon: </label>{ updatedUser.profile_fields.useGravatar ? 'Gravatar' : 'Default' }
 				</span>
 			</div>
-			<div className="info-holder">
-				<div className="instances">
-					<div className="top">
+			<div className='info-holder'>
+				{ suRender }
+				<div className='instances admin-subsection'>
+					<div className='top'>
 						<h2>Owned or Managed Instances:</h2>
 					</div>
 					<ul>
 						{ instancesAvailable }
 					</ul>
 				</div>
-				<div className="instances">
-					<div className="top">
+				<div className='instances admin-subsection'>
+					<div className='top'>
 						<h2>Instance Play History:</h2>
 					</div>
 					<ul>
@@ -109,22 +116,6 @@ const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 				</div>
 			</div>
 		</section>
-
-
-
-		// avatar icon, name
-		// created: static date
-		// last login: static date
-		// username: static string value
-		// email: input box
-		// role: drop-down
-		// notifications: checkmark true/false
-		// user icon: drop-down
-
-		// instances available section
-		// instances played section
-
-		// save changes btn
 	)
 }
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -249,6 +249,19 @@ export const apiUpdateUserSettings = (settings) => {
 		.then((resp) => resp.json())
 }
 
+export const apiUpdateUserRoles = (roles) => {
+	return fetch('/api/user/roles', {
+		...fetchOptions({}),
+		headers: {
+			pragma: 'no-cache',
+			'cache-control': 'no-cache',
+			'content-type': 'application/json'
+		},
+		body: JSON.stringify(roles)
+	})
+		.then((resp) => resp.json())
+}
+
 export const apiGetNotifications = () => {
 	return fetch('/api/json/notifications_get/', fetchOptions({ body: `data=${formatFetchBody([])}` }))
 		.then(resp => {


### PR DESCRIPTION
Adds a section to the user admin panel to manage roles for the given user. This includes a toggle between the student author roles as well as support users. You cannot add or remove the `super_user` role through this panel.

Note: this interface is only available to superusers. To test, you can grant a user the `super_user` role via the oil cli:

In `Materia/docker`:
```
./run.sh php oil r admin:give_user_role <username> super_user
```